### PR TITLE
Add mongo_replset and pool to modules list in .app file

### DIFF
--- a/ebin/mongodb.app
+++ b/ebin/mongodb.app
@@ -1,7 +1,7 @@
 {application, mongodb,
  [{description, "Client interface to MongoDB, also known as the driver. See www.mongodb.org"},
   {vsn, "0.0"},
-  {modules, [mongodb_app, mongo, mongo_protocol, mongo_connect, mongo_query, mongo_cursor, mvar, mongodb_tests]},
+  {modules, [mongodb_app, mongo, mongo_protocol, mongo_connect, mongo_query, mongo_cursor, mvar, mongodb_tests, mongo_replset, pool]},
   {registered, []},
   {applications, [kernel, stdlib]},
   {mod, {mongodb_app, []}}


### PR DESCRIPTION
Systools requires that all modules provided by an application be present here.

Have you considered building this project and bson-erlang with Rebar? It will generate the .app file for you, including building the modules list automatically.

I am building both with Rebar locally and would be happy to send another pull request migrating to a Rebar build if you are interested.

Thanks!
