### PR TITLE
updated .app module list 

### DIFF
--- a/ebin/mongodb.app
+++ b/ebin/mongodb.app
@@ -1,7 +1,7 @@
 {application, mongodb,
  [{description, "Client interface to MongoDB, also known as the driver. See www.mongodb.org"},
   {vsn, "0.0"},
-  {modules, [mongodb_app, mongo, mongo_protocol, mongo_connect, mongo_query, mongo_cursor, mvar, mongodb_tests]},
+  {modules, [mongodb_app, mongo, mongo_protocol, mongo_connect, mongo_query, mongo_cursor, mvar, mongodb_tests, mongo_replset, pool]},
   {registered, []},
   {applications, [kernel, stdlib]},
   {mod, {mongodb_app, []}}


### PR DESCRIPTION
Two modules missing from list. Rebar treats this as an error, and stops compilation when the project's included as a dependency:

ak@rifter:~/eg/mtry$ rebar compile
==> mongodb (compile)
ERROR: One or more .beam files exist that are not listed in mongodb.app:
    \* mongo_replset
    \* pool
ak@rifter:~/eg/mtry$ 

Adding 'em makes mongodb-erlang rebar-compatible. :)
