### PR TITLE
Rename pool to resource_pool to avoid conflict with pool module from stdlib

### DIFF
--- a/ebin/mongodb.app
+++ b/ebin/mongodb.app
@@ -1,7 +1,7 @@
 {application, mongodb,
  [{description, "Client interface to MongoDB, also known as the driver. See www.mongodb.org"},
   {vsn, "0.0"},
-  {modules, [mongodb_app, mongo, mongo_protocol, mongo_connect, mongo_query, mongo_cursor, mvar, mongodb_tests, mongo_replset, pool]},
+  {modules, [mongodb_app, mongo, mongo_protocol, mongo_connect, mongo_query, mongo_cursor, mvar, mongodb_tests, mongo_replset, resource_pool]},
   {registered, []},
   {applications, [kernel, stdlib]},
   {mod, {mongodb_app, []}}

--- a/src/mongodb_tests.erl
+++ b/src/mongodb_tests.erl
@@ -17,7 +17,7 @@ test() -> eunit:test ({setup,
 	 fun app_test/0,
 	 fun connect_test/0,
 	 fun mongo_test/0,
-	 fun pool_test/0
+	 fun resource_pool_test/0
 	]}).
 
 test_rs() -> eunit:test ({setup,
@@ -101,16 +101,16 @@ mongo_test() ->
 	mongo:disconnect (Conn).
 
 % Mongod server must be running on 127.0.0.1:27017
-pool_test() ->
-	Pool = pool:new (mongo:connect_factory ({"127.0.0.1", 27017}), 2),
+resource_pool_test() ->
+	Pool = resource_pool:new (mongo:connect_factory ({"127.0.0.1", 27017}), 2),
 	Do = fun (Conn) -> mongo:do (safe, master, Conn, admin, fun () -> mongo:command ({listDatabases, 1}) end) end,
 	lists:foreach (fun (_) ->
-			{ok, Conn} = pool:get (Pool),
+			{ok, Conn} = resource_pool:get (Pool),
 			{ok, Doc} = Do (Conn),
 			{_} = bson:lookup (databases, Doc) end,
 		lists:seq (1,8)),
-	pool:close (Pool),
-	true = pool:is_closed (Pool).
+	resource_pool:close (Pool),
+	true = resource_pool:is_closed (Pool).
 
 % Replica set named "rs1" must be running on localhost:27017 & 27018
 replset_test() -> % TODO: change from connect_test

--- a/src/resource_pool.erl
+++ b/src/resource_pool.erl
@@ -1,5 +1,5 @@
 %@doc A set of N resources handed out randomly, and recreated on expiration
--module (pool).
+-module (resource_pool).
 
 -export_type ([factory/1, create/1, expire/1, is_expired/1]).
 -export_type ([pool/1]).


### PR DESCRIPTION
Otherwise the stdlib "pool" module hides the mongodb one when it is loaded later.
